### PR TITLE
Fix ValueError in legacy_ftl_id() and allow disabling legacy FTL

### DIFF
--- a/hum.php
+++ b/hum.php
@@ -410,10 +410,32 @@ class Hum {
 	 * @return string ID of post to redirect to.
 	 */
 	public function legacy_ftl_id( $id, $path ) {
+		/**
+		 * Filters whether Hum resolves legacy Friendly Twitter Links shortlinks.
+		 *
+		 * These are bare base-10 or base-32 post IDs used as the request path.
+		 * Sites that never used FTL shortlinks can disable this to stop Hum from
+		 * decoding arbitrary 404 URLs into post IDs and redirecting to them.
+		 *
+		 * @param bool $enabled Whether to resolve legacy FTL shortlinks. Default true.
+		 */
+		if ( ! apply_filters( 'hum_enable_legacy_ftl', true ) ) {
+			return $id;
+		}
+
 		if ( is_numeric( $path ) ) {
 			$post = get_post( $path );
 		} else {
-			$post_id = base_convert( preg_replace( '/[^0-9a-fA-F]/', '', $path ), 32, 10 );
+			$base32 = preg_replace( '/[^0-9a-fA-F]/', '', $path );
+
+			// A base-32 post ID is never wider than PHP_INT_MAX (13 characters).
+			// Anything longer cannot be a valid ID and overflows base_convert() to
+			// INF, which throws a ValueError on PHP 8, so bail before converting.
+			if ( '' === $base32 || strlen( $base32 ) > 13 ) {
+				return $id;
+			}
+
+			$post_id = base_convert( $base32, 32, 10 );
 			$post    = get_post( $post_id );
 		}
 


### PR DESCRIPTION
## Summary

`Hum::legacy_ftl_id()` (hooked on `hum_legacy_id`, run from `legacy_redirect()` on every 404)
strips non-hex characters from the request path and `base_convert( …, 32, 10 )`'s the remainder
into a post ID to redirect to. This causes two problems on PHP 8:

### 1. `ValueError` on long paths

A long request path leaves a long hex string, and `base_convert()` overflows the intermediate
value to `INF`. PHP 8 then throws:

```
ValueError: An infinite value cannot be converted to base 10
```

(PHP 7 silently returned a float-like string.) Repro:

```php
base_convert( str_repeat( 'f', 400 ), 32, 10 ); // PHP 8: ValueError
```

In the wild this fires when a bot requests a malformed URL — e.g. an entire image `srcset`
attribute used as a single path — which survives the `[^0-9a-fA-F]` strip as a long hex string.
This is the same crash reported in #41 (closed as stale for lack of a reproducer).

**Fix:** bail before converting when the stripped string is empty or longer than 13 characters —
the width of `PHP_INT_MAX` in base 32 (`7vvvvvvvvvvvv`). Anything longer cannot be a valid post ID.

### 2. Legacy FTL decoder hijacks ordinary 404 URLs

Because the decoder matches *any* 404 path, ordinary URLs decode to post IDs and 301-redirect.
For example `/blog/` strips to `b`, decodes to post `11`, and redirects there — surprising on
sites that never used Friendly Twitter Links.

**Fix:** add a `hum_enable_legacy_ftl` filter, **defaulting to `true`** (no behaviour change), so
sites that never used FTL shortlinks can disable the decoder:

```php
add_filter( 'hum_enable_legacy_ftl', '__return_false' );
```

If you'd prefer this to be opt-in (default `false`) in a future major version, happy to adjust.

## Testing

- `phpcs` (WordPress-Core) passes clean.
- Long path → bails, no `ValueError`. Empty/over-length stripped string → `$id` unchanged.
- Valid short IDs still resolve as before; `hum_enable_legacy_ftl => false` disables the decoder.

Refs #41.